### PR TITLE
Initialize zero collision force for film breakup

### DIFF
--- a/examples/drop_breakup/src/simulation.f90
+++ b/examples/drop_breakup/src/simulation.f90
@@ -814,6 +814,7 @@ contains
                ! Add the drop
                lp%p(np)%id  =int(0,8)                                                                                 !< Give id (maybe based on break-up model?)
                lp%p(np)%dt  =0.0_WP                                                                                   !< Let the drop find it own integration time
+               lp%p(np)%col =0.0_WP                                                                                   !< Give zero collision force
                lp%p(np)%d   =diam                                                                                     !< Assign diameter to account for full volume
                lp%p(np)%pos =[cc%meta_structures_list(m)%x,cc%meta_structures_list(m)%y,cc%meta_structures_list(m)%z] !< Place the drop at the liquid barycenter
                lp%p(np)%vel =[cc%meta_structures_list(m)%u,cc%meta_structures_list(m)%v,cc%meta_structures_list(m)%w] !< Assign mean structure velocity as drop velocity
@@ -888,6 +889,7 @@ contains
                   ! Add the drop
                   lp%p(np)%id  =int(0,8)                                   !< Give id (maybe based on break-up model?)
                   lp%p(np)%dt  =0.0_WP                                     !< Let the drop find it own integration time
+                  lp%p(np)%col =0.0_WP                                     !< Give zero collision force
                   lp%p(np)%d   =(6.0_WP*Vd/pi)**(1.0_WP/3.0_WP)            !< Assign diameter from model above
                   lp%p(np)%pos =vf%Lbary(:,i,j,k)                          !< Place the drop at the liquid barycenter
                   lp%p(np)%vel =fs%cfg%get_velocity(pos=lp%p(np)%pos,i0=i,j0=j,k0=k,U=fs%U,V=fs%V,W=fs%W) !< Interpolate local cell velocity as drop velocity
@@ -910,6 +912,7 @@ contains
                ! Add the drop
                lp%p(np)%id  =int(0,8)                                   !< Give id (maybe based on break-up model?)
                lp%p(np)%dt  =0.0_WP                                     !< Let the drop find it own integration time
+               lp%p(np)%col =0.0_WP                                     !< Give zero collision force
                lp%p(np)%d   =(6.0_WP*Vl/pi)**(1.0_WP/3.0_WP)            !< Assign diameter based on remaining liquid volume
                lp%p(np)%pos =vf%Lbary(:,i,j,k)                          !< Place the drop at the liquid barycenter
                lp%p(np)%vel =fs%cfg%get_velocity(pos=lp%p(np)%pos,i0=i,j0=j,k0=k,U=fs%U,V=fs%V,W=fs%W) !< Interpolate local cell velocity as drop velocity

--- a/examples/nozzle_2phase/src/simulation.f90
+++ b/examples/nozzle_2phase/src/simulation.f90
@@ -852,6 +852,7 @@ contains
                   ! Add the drop
                   lp%p(np)%id  =int(0,8)                                   !< Give id (maybe based on break-up model?)
                   lp%p(np)%dt  =0.0_WP                                     !< Let the drop find it own integration time
+                  lp%p(np)%col =0.0_WP                                     !< Give zero collision force
                   lp%p(np)%d   =(6.0_WP*Vd/pi)**(1.0_WP/3.0_WP)            !< Assign diameter from model above
                   lp%p(np)%pos =vf%Lbary(:,i,j,k)                          !< Place the drop at the liquid barycenter
                   lp%p(np)%vel =fs%cfg%get_velocity(pos=lp%p(np)%pos,i0=i,j0=j,k0=k,U=fs%U,V=fs%V,W=fs%W) !< Interpolate local cell velocity as drop velocity
@@ -874,6 +875,7 @@ contains
                ! Add the drop
                lp%p(np)%id  =int(0,8)                                   !< Give id (maybe based on break-up model?)
                lp%p(np)%dt  =0.0_WP                                     !< Let the drop find it own integration time
+               lp%p(np)%col =0.0_WP                                     !< Give zero collision force
                lp%p(np)%d   =(6.0_WP*Vl/pi)**(1.0_WP/3.0_WP)            !< Assign diameter based on remaining liquid volume
                lp%p(np)%pos =vf%Lbary(:,i,j,k)                          !< Place the drop at the liquid barycenter
                lp%p(np)%vel =fs%cfg%get_velocity(pos=lp%p(np)%pos,i0=i,j0=j,k0=k,U=fs%U,V=fs%V,W=fs%W) !< Interpolate local cell velocity as drop velocity

--- a/examples/nozzle_3grids/src/simulation.f90
+++ b/examples/nozzle_3grids/src/simulation.f90
@@ -1529,6 +1529,7 @@ contains
                ! Add the drop
                lp3%p(np)%id  =int(0,8)                                                                                      !< Give id (maybe based on break-up model?)
                lp3%p(np)%dt  =0.0_WP                                                                                        !< Let the drop find it own integration time
+               lp3%p(np)%col =0.0_WP                                                                                        !< Give zero collision force               
                lp3%p(np)%d   =diam                                                                                          !< Assign diameter to account for full volume
                lp3%p(np)%pos =[cc2%meta_structures_list(m)%x,cc2%meta_structures_list(m)%y,cc2%meta_structures_list(m)%z]   !< Place the drop at the liquid barycenter
                lp3%p(np)%vel =[cc2%meta_structures_list(m)%u,cc2%meta_structures_list(m)%v,cc2%meta_structures_list(m)%w]   !< Assign mean structure velocity as drop velocity
@@ -1603,6 +1604,7 @@ contains
                   ! Add the drop
                   lp3%p(np)%id  =int(0,8)                                   !< Give id (maybe based on break-up model?)
                   lp3%p(np)%dt  =0.0_WP                                     !< Let the drop find it own integration time
+                  lp3%p(np)%col =0.0_WP                                     !< Give zero collision force
                   lp3%p(np)%d   =(6.0_WP*Vd/pi)**(1.0_WP/3.0_WP)            !< Assign diameter from model above
                   lp3%p(np)%pos =vf2%Lbary(:,i,j,k)                         !< Place the drop at the liquid barycenter
                   lp3%p(np)%vel =fs2%cfg%get_velocity(pos=lp3%p(np)%pos,i0=i,j0=j,k0=k,U=fs2%U,V=fs2%V,W=fs2%W) !< Interpolate local cell velocity as drop velocity
@@ -1625,6 +1627,7 @@ contains
                ! Add the drop
                lp3%p(np)%id  =int(0,8)                                   !< Give id (maybe based on break-up model?)
                lp3%p(np)%dt  =0.0_WP                                     !< Let the drop find it own integration time
+               lp3%p(np)%col =0.0_WP                                     !< Give zero collision force
                lp3%p(np)%d   =(6.0_WP*Vl/pi)**(1.0_WP/3.0_WP)            !< Assign diameter based on remaining liquid volume
                lp3%p(np)%pos =vf2%Lbary(:,i,j,k)                         !< Place the drop at the liquid barycenter
                lp3%p(np)%vel =fs2%cfg%get_velocity(pos=lp3%p(np)%pos,i0=i,j0=j,k0=k,U=fs2%U,V=fs2%V,W=fs2%W) !< Interpolate local cell velocity as drop velocity


### PR DESCRIPTION
The older examples didn't initialize the collision force, and the particle integration would hang because col would be NaN.