### PR TITLE
updating shock sensor

### DIFF
--- a/src/two_phase/mast_class.f90
+++ b/src/two_phase/mast_class.f90
@@ -1317,7 +1317,7 @@ contains
        cb=abs(sum(this%divp_x(:,i,j,k)*this%U(i:i+1,j,k)) &
             + sum(this%divp_y(:,i,j,k)*this%V(i,j:j+1,k)) &
             + sum(this%divp_z(:,i,j,k)*this%W(i,j,k:k+1)))&
-            - min(this%cfg%dxi(i),this%cfg%dyi(j),this%cfg%dzi(k)) &
+            - max(this%cfg%dxi(i),this%cfg%dyi(j),this%cfg%dzi(k)) &
             * sqrt(this%RHOSS2(i,j,k)/this%RHO(i,j,k)) / this%shs_wt
 
      end function shock_sensor


### PR DESCRIPTION
Updates shock sensor in mast_class.f90 to use minimum local mesh dimension based on equation (34). Since the inverse mesh spacing was being used, the min() function would use the largest mesh spacing in the shock sensor. This update changes min() to max() to use the smallest local mesh spacing as described by equation (34).