### PR TITLE
Develop - updating shock/droplet example

### DIFF
--- a/examples/shock_droplet/input
+++ b/examples/shock_droplet/input
@@ -30,6 +30,9 @@ Liquid Mach number : 0.01
 Shock Mach number : 1.47
 Liquid gamma :	      	      4.4
 Gas gamma : 		      1.4
+Gas constant:                 287
+Gas Prandtl number:	      0.71
+Thermal conductivity ratio:   23.4
 
 # Time integration
 Max timestep size : 5e-2

--- a/examples/shock_droplet/src/simulation.f90
+++ b/examples/shock_droplet/src/simulation.f90
@@ -186,7 +186,8 @@ contains
          call param_read('Gas Mach number',Mag); Pref = 1.0_WP/(gamm_g*Mag**2)
          call param_read('Liquid Mach number',Mal); Pref_l = r_rho/(gamm_l*Mal**2) - Pref
          call param_read('Gas constant', R)
-         call param_read('Gas Prandtl number', g_Pr); hdff_g = (R*gamm_g/(gamm_g-1.0_WP))*visc_g/g_Pr
+         ! Unphysical temperature gradient, so decreasing kappa values for convergence for example
+         call param_read('Gas Prandtl number', g_Pr); hdff_g = 0.01_WP*(R*gamm_g/(gamm_g-1.0_WP))*visc_g/g_Pr
          call param_read('Thermal conductivity ratio',r_hdff); hdff_l=hdff_g*r_hdff;
          
          ! Register equations of state

--- a/examples/shock_droplet/src/simulation.f90
+++ b/examples/shock_droplet/src/simulation.f90
@@ -186,7 +186,7 @@ contains
          call param_read('Gas Mach number',Mag); Pref = 1.0_WP/(gamm_g*Mag**2)
          call param_read('Liquid Mach number',Mal); Pref_l = r_rho/(gamm_l*Mal**2) - Pref
          call param_read('Gas constant', R)
-         call param_read('Gas Prandtl number', g_Pr); hdff_g = (R*gamma_g/(gamma_g-1.0_WP))*visc_g/g_Pr
+         call param_read('Gas Prandtl number', g_Pr); hdff_g = (R*gamm_g/(gamm_g-1.0_WP))*visc_g/g_Pr
          call param_read('Thermal conductivity ratio',r_hdff); hdff_l=hdff_g*r_hdff;
          
          ! Register equations of state


### PR DESCRIPTION
Feel free to reject/modify as you see fit. In the shock/droplet example there was no initialization of the thermal conductivity for the material models, and the kappa values are currently taken to be the default parameters based on state. I incorporated Pr into the input file, but I decreased the actual kappa values by a factor of 100 in order for the pressure solver to converge with the original settings. There is a non-physical temperature gradient between the liquid and the gas currently due to the liquid EoS.